### PR TITLE
Clean bootstrap.resample docstrings

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -160,7 +160,7 @@ def confidence_interval(
 
     Returns
     -------
-    (l, u) : tuple
+    (float, float)
         Upper and lower confidence limits
     """
     if not 0 < cl < 1:

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -41,7 +41,7 @@ def resample(
 
     Notes
     -----
-    If data is not iid, but consists of several distinct classes, stratification
+    If data is not i.i.d. but consists of several distinct classes, stratification
     ensures that the relative proportions of each class are maintained in each
     replicated sample. This is a stricter constraint than that offered by the
     balanced bootstrap, which only guarantees that classes have the original

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -144,6 +144,12 @@ def confidence_interval(
 
     Notes
     -----
+    Bootstrap interval estimates are valid for a broad range of common applications,
+    such as when estimating means, variances, correlations, or regression coefficients.
+    However, keep in mind that there are situations where the bootstrap will give
+    misleading results; for instance, when making inferences about the extremes of
+    distributions.
+
     Both the 'percentile' and 'bca' methods produce intervals that are invariant to
     monotonic transformations of the data values, a desirable and consistent property.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -24,8 +24,8 @@ def resample(
     ----------
     sample : array-like
         Original sample.
-    size : int, optional
-        Number of bootstrap samples to generate. Default is 1000.
+    size : int, default 100
+        Number of bootstrap samples to generate.
     method : str or None, optional
         How to generate bootstrap samples. Supported are 'ordinary', 'balanced', or
         a distribution name for a parametric bootstrap. Default is 'balanced'.

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -24,8 +24,8 @@ def resample(
     ----------
     sample : array-like
         Original sample.
-    size : int, default 100
-        Number of bootstrap samples to generate.
+    size : int, optional
+        Number of bootstrap samples to generate. Default is 100.
     method : str or None, optional
         How to generate bootstrap samples. Supported are 'ordinary', 'balanced', or
         a distribution name for a parametric bootstrap. Default is 'balanced'.
@@ -135,7 +135,7 @@ def confidence_interval(
     cl : float, default : 0.95
         Confidence level. Asymptotically, this is the probability that the interval
         contains the true value.
-    ci_method : str, {'bca', 'percentile'}, default 'bca'
+    ci_method : str, {'bca', 'percentile'}, optional
         Confidence interval method. Default is 'bca'. See notes for details.
     **kwargs
         Keyword arguments forwarded to :func:`resample`.

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -142,12 +142,6 @@ def confidence_interval(
 
     Notes
     -----
-    Bootstrap interval estimates are valid for a broad range of common applications,
-    such as when estimating means, variances, correlations, or regression coefficients.
-    However, keep in mind that there are situations where the bootstrap will give
-    misleading results; for instance, when making inferences about the extremes of
-    distributions.
-
     Both the 'percentile' and 'bca' methods produce intervals that are invariant to
     monotonic transformations of the data values, a desirable and consistent property.
 

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -137,7 +137,7 @@ def confidence_interval(
     cl : float, default : 0.95
         Confidence level. Asymptotically, this is the probability that the interval
         contains the true value.
-    ci_method : str, {'bca', 'percentile'}, optional
+    ci_method : str, {'bca', 'percentile'}, default 'bca'
         Confidence interval method. Default is 'bca'. See notes for details.
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
@@ -147,11 +147,11 @@ def confidence_interval(
     Both the 'percentile' and 'bca' methods produce intervals that are invariant to
     monotonic transformations of the data values, a desirable and consistent property.
 
-    The 'percentile' method is straight-forward and useful as a fallback. The 'bca'
+    The 'percentile' method is straightforward and useful as a fallback. The 'bca'
     method is 2nd order accurate (to O(1/n) where n is the sample size) and generally
-    perferred. It computes a jackknife estimate in addition to the bootstrap, which
+    preferred. It computes a jackknife estimate in addition to the bootstrap, which
     increases the number of function evaluations in a direct comparison to
-    'percentile', but in the increase in accuracy should over-compensate this, with the
+    'percentile'. However the increase in accuracy should compensate for this, with the
     result that less bootstrap replicas are needed overall to achieve the same accuracy.
 
     Returns

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -18,7 +18,7 @@ def resample(
     random_state: Optional[Union[np.random.Generator, int]] = None,
 ) -> Generator[np.ndarray, None, None]:
     """
-    Generator of bootstrap samples.
+    Return generator of bootstrap samples.
 
     Parameters
     ----------
@@ -197,9 +197,10 @@ def bias(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
 
     Notes
     -----
-    This function has special space requirements, it needs to hold `size` replicas of
-    the original sample in memory at once. The balanced bootstrap is recommended over
-    the ordinary bootstrap for bias estimation, it tends to converge faster.
+    This function has special space requirements in that it needs to hold `size`
+    replicas of the original sample in memory at once. The balanced bootstrap is
+    recommended over the ordinary bootstrap for bias estimation as it tends to
+    converge faster.
 
     Returns
     -------

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -41,8 +41,6 @@ def resample(
 
     Notes
     -----
-    Stratification:
-
     If data is not iid, but consists of several distinct classes, stratification
     ensures that the relative proportions of each class are maintained in each
     replicated sample. This is a stricter constraint than that offered by the

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -191,16 +191,9 @@ def bias(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
 
     Notes
     -----
-<<<<<<< HEAD
-    This function has special space requirements in that it needs to hold `size`
-    replicas of the original sample in memory at once. The balanced bootstrap is
-    recommended over the ordinary bootstrap for bias estimation as it tends to
-    converge faster.
-=======
     This function has special space requirements, it needs to hold `size` replicates of
     the original sample in memory at once. The balanced bootstrap is recommended over
     the ordinary bootstrap for bias estimation, it tends to converge faster.
->>>>>>> origin/master
 
     Returns
     -------


### PR DESCRIPTION
Some docstring cleanup: ~ci_method isn't optional and default is "bca"~, also some small spelling / stylistic changes. In addition I added a note about possible failure of the bootstrap, but feel free to suggest changes.

Edit: Noticed the docstring for bootstrap.resample is not right either so doing more general clean up.