### PR TITLE
Optional error estimates computed with jackknife-after-bootstrap method

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -217,7 +217,7 @@ def bias(fn: Callable, sample: Sequence, error: bool = False, **kwargs) -> np.nd
         return np.mean(thetas, axis=0) - population_theta
 
     if error:
-        return _jackknife_after_bootstrap(bias, thetas, resampled, sample)
+        return _jackknife_after_bootstrap(bias, np.array(thetas), resampled, sample)
     return bias(thetas)
 
 
@@ -375,11 +375,9 @@ def _jackknife_after_bootstrap(
     # Tibshirani, An introduction to the bootstrap.
     n = len(sample)
     jack = [[] for i in range(n)]
-    thetas = []
     for i, b in enumerate(resampled):
-        thetas.append(fn(resampled))
         for j, s in enumerate(sample):
-            if s not in resampled:
+            if np.any(s == b):
                 jack[j].append(i)
     result = fn(thetas)
     jack = [fn(thetas[indices]) if indices else result for indices in jack]

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -1,7 +1,7 @@
 """
 Bootstrap resampling.
 """
-from typing import Callable, Generator, Optional, Sequence, Tuple, Union
+from typing import Callable, Generator, Optional, Sequence, Tuple, Union, List
 
 import numpy as np
 from scipy import stats
@@ -369,12 +369,12 @@ def _confidence_interval_bca(
 
 
 def _jackknife_after_bootstrap(
-    fn: Callable, thetas: Sequence, resampled: Sequence, sample: Sequence
+    fn: Callable, thetas: np.ndarray, resampled: np.ndarray, sample: np.ndarray
 ) -> Tuple[np.ndarray, np.ndarray]:
     # computes the jackknife-after-bootstrap, as described in the book Efron &
     # Tibshirani, An introduction to the bootstrap.
     n = len(sample)
-    jack = [[] for i in range(n)]
+    jack: List[List[int]] = [[] for i in range(n)]
     for i, b in enumerate(resampled):
         for j, s in enumerate(sample):
             if np.any(s == b):

--- a/resample/tests/test_bootstrap.py
+++ b/resample/tests/test_bootstrap.py
@@ -228,15 +228,15 @@ def test_confidence_interval_invalid_ci_method_raises():
 
 
 @pytest.mark.parametrize("method", ("ordinary", "balanced"))
-def test_bias_on_unbiased(method, rng):
-    data = (0, 1, 2, 3)
-    r = bias(np.mean, data, method="balanced", random_state=rng)
+@pytest.mark.parametrize("error", (False, True))
+def test_bias_on_unbiased(method, error, rng):
+    data = (0, 1, 2, 3, 4, 5)
+    r = bias(np.mean, data, method=method, error=error, random_state=rng)
 
-    if method == "balanced":
-        # bias is exactly zero for linear functions with the balanced bootstrap
-        assert r == 0
+    if error:
+        assert r[0] == pytest.approx(0)
+        assert r[1] == pytest.approx(0.38, abs=0.01)
     else:
-        # bias is not exactly zero for ordinary bootstrap
         assert r == pytest.approx(0)
 
 


### PR DESCRIPTION
This adds an optional error estimates for `resample.bootstrap.bias`, computed with the jackknife-after-bootstrap method. The computation is toggled with a new keyword `error`, whose default is `False`.

@dsaxton If you agree with this solution, then I will add this functionality also to `bias_corrected` and `variance`. I make a draft pull request, but need your feedback on the draft.

My original idea was to have the jackknife-after-bootstrap as a separate function, but during implementing I saw that an efficient implementation requires this to be called from within `resample.bootstrap.bias`.