### PR TITLE
Fix numpydoc errors

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -39,6 +39,11 @@ def resample(
         Random number generator instance. If an integer is passed, seed the numpy
         default generator with it. Default is to use `numpy.random.default_rng()`.
 
+    Yields
+    ------
+    ndarray
+        Bootstrap sample.
+
     Notes
     -----
     If data is not i.i.d. but consists of several distinct classes, stratification
@@ -46,11 +51,6 @@ def resample(
     replicated sample. This is a stricter constraint than that offered by the
     balanced bootstrap, which only guarantees that classes have the original
     proportions over all replicates.
-
-    Yields
-    ------
-    ndarray
-        Bootstrap sample.
     """
     if random_state is None:
         rng = np.random.default_rng()
@@ -140,6 +140,11 @@ def confidence_interval(
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
+    Returns
+    -------
+    (float, float)
+        Upper and lower confidence limits.
+
     Notes
     -----
     Both the 'percentile' and 'bca' methods produce intervals that are invariant to
@@ -151,11 +156,6 @@ def confidence_interval(
     increases the number of function evaluations in a direct comparison to
     'percentile'. However the increase in accuracy should compensate for this, with the
     result that less bootstrap replicas are needed overall to achieve the same accuracy.
-
-    Returns
-    -------
-    (float, float)
-        Upper and lower confidence limits
     """
     if not 0 < cl < 1:
         raise ValueError("cl must be between zero and one")
@@ -189,16 +189,16 @@ def bias(fn: Callable, sample: Sequence, **kwargs) -> np.ndarray:
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
+    Returns
+    -------
+    ndarray
+        Bootstrap estimate of bias (= expectation of estimator - true value).
+
     Notes
     -----
     This function has special space requirements, it needs to hold `size` replicates of
     the original sample in memory at once. The balanced bootstrap is recommended over
     the ordinary bootstrap for bias estimation, it tends to converge faster.
-
-    Returns
-    -------
-    ndarray
-        Bootstrap estimate of bias (= expectation of estimator - true value).
     """
     replicates = []
     thetas = []

--- a/resample/empirical.py
+++ b/resample/empirical.py
@@ -64,8 +64,7 @@ def quantile_function_gen(sample: Sequence) -> Callable:
 
 def influence(fn: Callable, sample: Sequence) -> np.ndarray:
     """
-    Calculate the empirical influence function for a given sample and estimator
-    using the jackknife method.
+    Calculate the empirical influence function for a given sample and estimator.
 
     Parameters
     ----------

--- a/resample/jackknife.py
+++ b/resample/jackknife.py
@@ -12,10 +12,10 @@ def resample(sample: Sequence, copy: bool = True) -> Generator[np.ndarray, None,
 
     Parameters
     ----------
-    sample: array-like
+    sample : array-like
         Sample. If the sequence is multi-dimensional, the first dimension must
         walk over i.i.d. observations.
-    copy: bool, optional
+    copy : bool, optional
         If `True`, return the replicated sample as a copy, otherwise return a view into
         the internal array buffer of the generator. Setting this to `False` avoids
         `len(sample)` copies, which is more efficient, but see notes for caveats.
@@ -26,6 +26,11 @@ def resample(sample: Sequence, copy: bool = True) -> Generator[np.ndarray, None,
         Array with same shape and type as input, but with the size of the first
         dimension reduced by one. Replicates are missing one value of the original in
         ascending order, e.g. for a sample (1, 2, 3), one gets (2, 3), (1, 3), (1, 2).
+
+    See Also
+    --------
+    resample.bootstrap.resample : Generate bootstrap samples.
+    resample.jackknife.jackknife : Generate jackknife samples.
 
     Notes
     -----
@@ -49,11 +54,6 @@ def resample(sample: Sequence, copy: bool = True) -> Generator[np.ndarray, None,
     ...     r2.append(x) # x is now a view into the same array in memory
     >>> print(r2)
     [array([1, 2]), array([1, 2]), array([1, 2])]
-
-    See Also
-    --------
-    resample.bootstrap.resample
-    resample.jackknife.jackknife
     """
     sample = np.atleast_1d(sample)
 
@@ -130,7 +130,7 @@ def bias(fn: Callable, sample: Sequence) -> np.ndarray:
 
 def bias_corrected(fn: Callable, sample: Sequence) -> np.ndarray:
     """
-    Calculates bias-corrected estimate of the function with the jackknife.
+    Calculate bias-corrected estimate of the function with the jackknife.
 
     Removes a bias of O(1/n), where n is the sample size, leaving bias of
     order O(1/n²). If the original function has a bias of exactly O(1/n),

--- a/resample/jackknife.py
+++ b/resample/jackknife.py
@@ -30,7 +30,7 @@ def resample(sample: Sequence, copy: bool = True) -> Generator[np.ndarray, None,
     See Also
     --------
     resample.bootstrap.resample : Generate bootstrap samples.
-    resample.jackknife.jackknife : Generate jackknife samples.
+    resample.jackknife.jackknife : Generate jackknife estimates.
 
     Notes
     -----

--- a/resample/permutation.py
+++ b/resample/permutation.py
@@ -28,7 +28,12 @@ def ttest(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> Di
         T statistic as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     a1 = np.asarray(a1)
     a2 = np.asarray(a2)
@@ -47,7 +52,7 @@ def ttest(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> Di
     n2 = len(a2)
 
     X = np.apply_along_axis(
-        func1d=np.random.permutation,
+        func1d=rng.permutation,
         arr=np.reshape(np.tile(np.append(a1, a2), b), newshape=(b, n1 + n2)),
         axis=1,
     )
@@ -77,7 +82,12 @@ def anova(args: List[np.ndarray], b: int = 100, random_state=None) -> Dict:
         F statistic as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     args = [np.asarray(a) for a in args]
     args = [a[~np.isnan(a)] for a in args]
@@ -106,7 +116,7 @@ def anova(args: List[np.ndarray], b: int = 100, random_state=None) -> Dict:
     f = g(arr)
 
     permute_f = np.apply_along_axis(
-        func1d=(lambda x: g(np.random.permutation(x))), arr=X, axis=1
+        func1d=(lambda x: g(rng.permutation(x))), arr=X, axis=1
     )
 
     return {"f": f, "prop": np.mean(permute_f <= f)}
@@ -134,7 +144,12 @@ def wilcoxon(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) ->
         W statistic as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     a1 = np.asarray(a1)
     a2 = np.asarray(a2)
@@ -149,7 +164,7 @@ def wilcoxon(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) ->
     a = rankdata(a)
 
     X = np.apply_along_axis(
-        func1d=np.random.permutation,
+        func1d=rng.permutation,
         arr=np.reshape(np.tile(a, b), newshape=(b, n1 + n2)),
         axis=1,
     )
@@ -181,7 +196,12 @@ def kruskal_wallis(args: List[np.ndarray], b: int = 100, random_state=None) -> D
         H statistic as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     args = [np.asarray(a) for a in args]
     args = [a[~np.isnan(a)] for a in args]
@@ -209,7 +229,7 @@ def kruskal_wallis(args: List[np.ndarray], b: int = 100, random_state=None) -> D
     h = g(r_arr)
 
     permute_h = np.apply_along_axis(
-        func1d=(lambda s: g(np.random.permutation(s))), arr=x, axis=1
+        func1d=(lambda s: g(rng.permutation(s))), arr=x, axis=1
     )
 
     return {"h": h, "prop": np.mean(permute_h > h)}
@@ -245,7 +265,12 @@ def corr_test(
         Correlation as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     a1 = np.asarray(a1)
     a2 = np.asarray(a2)
@@ -277,7 +302,7 @@ def corr_test(
 
     c = corr(a[:, 0], a[:, 1])
 
-    permute_c = np.asarray([corr(np.random.permutation(x[:, 0]), x[:, 1]) for x in X])
+    permute_c = np.asarray([corr(rng.permutation(x[:, 0]), x[:, 1]) for x in X])
 
     return {"c": c, "prop": np.mean(permute_c <= c)}
 
@@ -304,7 +329,12 @@ def ks_test(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> 
         D statistic as well as proportion of permutation distribution less than or
         equal to that statistic.
     """
-    np.random.seed(random_state)
+    if random_state is None:
+        rng = np.random.default_rng()
+    elif isinstance(random_state, int):
+        rng = np.random.default_rng(random_state)
+    else:
+        rng = random_state
 
     a1 = np.asarray(a1)
     a2 = np.asarray(a2)
@@ -326,7 +356,7 @@ def ks_test(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> 
 
     def g(s):
         mask = np.ones(n, dtype=np.bool)
-        mask[np.random.choice(range(n), size=n2, replace=False)] = False
+        mask[rng.choice(range(n), size=n2, replace=False)] = False
 
         return np.max([abs(h(s[mask], i, n1) - h(s[~mask], i, n2)) for i in s])
 

--- a/resample/permutation.py
+++ b/resample/permutation.py
@@ -8,28 +8,25 @@ from resample.empirical import cdf_gen
 
 def ttest(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> Dict:
     """
-    Perform permutation two sample t-test (the mean of a2 is subtracted from that of
-    a1).
+    Perform permutation two sample t-test.
 
     Parameters
     ----------
     a1 : array-like
-        First sample
-
+        First sample.
     a2 : array-like
-        Second sample
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Second sample.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'t', 'prop'} : {float, float}
-        T statistic as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'t': float, 'prop': float}
+        T statistic as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 
@@ -67,19 +64,18 @@ def anova(args: List[np.ndarray], b: int = 100, random_state=None) -> Dict:
     Parameters
     ----------
     args : sequence of array-like
-        Samples
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Samples.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'f', 'prop'} : {float, float}
-        F statistic as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'f': float, 'prop': float}
+        F statistic as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 
@@ -123,22 +119,20 @@ def wilcoxon(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) ->
     Parameters
     ----------
     a1 : array-like
-        First sample
-
+        First sample.
     a2 : array-like
-        Second sample
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Second sample.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'w', 'prop'} : {int, float}
-        W statistic as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'w': float, 'prop': float}
+        W statistic as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 
@@ -174,19 +168,18 @@ def kruskal_wallis(args: List[np.ndarray], b: int = 100, random_state=None) -> D
     Parameters
     ----------
     args : sequence of array-like
-        Samples
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Samples.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'h', 'prop'} : {float, float}
-        H statistic as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'h': float, 'prop': flaot}
+        H statistic as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 
@@ -235,25 +228,22 @@ def corr_test(
     Parameters
     ----------
     a1 : array-like
-        First sample
-
+        First sample.
     a2 : array-like
-        Second sample
-
-    method : str, {'pearson', 'spearman'}, default : 'pearson'
-        Correlation method
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Second sample.
+    method : str, {'pearson', 'spearman'}, optional
+        Correlation method. Default 'pearson'.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'corr', 'prop'} : {float, float}
-        Correlation as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'corr': float, 'prop': float}
+        Correlation as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 
@@ -299,22 +289,20 @@ def ks_test(a1: np.ndarray, a2: np.ndarray, b: int = 100, random_state=None) -> 
     Parameters
     ----------
     a1 : array-like
-        First sample
-
+        First sample.
     a2 : array-like
-        Second sample
-
-    b : int, default : 100
-        Number of permutations
-
-    random_state : int or None, default : None
-        random number seed
+        Second sample.
+    b : int, optional
+        Number of permutations. Default 100.
+    random_state : numpy.random.Generator or int, optional
+        Random number generator instance. If an integer is passed, seed the numpy
+        default generator with it. Default is to use `numpy.random.default_rng()`.
 
     Returns
     -------
-    {'d', 'prop'} : {float, float}
-        D statistic as well as proportion of permutation
-        distribution less than or equal to that statistic
+    {'d': float, 'prop': float}
+        D statistic as well as proportion of permutation distribution less than or
+        equal to that statistic.
     """
     np.random.seed(random_state)
 


### PR DESCRIPTION
Fixing some numpydoc errors (e.g., Notes should go after Yields / Returns). I think adding numpydoc validation to CI could also be good.

Edit: while updating noticed that permutation.py is still using np.random.seed so switched over to using the rng instead.