### PR TITLE
Remove issue #85

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ _build
 benchmarks/.asv/
 junit
 py[0-9]*
+.env
+.vscode

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -353,6 +353,7 @@ def _confidence_interval_bca(
     z_naught = norm.ppf(prop_less)
 
     # acceleration
+    j_thetas = j_thetas.astype('float64')
     j_thetas -= np.mean(j_thetas)
     num = np.sum((-j_thetas) ** 3)
     den = np.sum(j_thetas ** 2)

--- a/resample/tests/test_confidence_interval.py
+++ b/resample/tests/test_confidence_interval.py
@@ -1,0 +1,8 @@
+from resample.bootstrap import confidence_interval as ci
+import numpy as np
+
+def estimator(data):
+    return int(np.mean(data))
+
+data = (1, 2, 3)
+print(ci(estimator, data))


### PR DESCRIPTION
Issue #85 highlighted that resample.bootstrap.confidence_interval fails if estimator returns an integer.

This pull request resolves this bug by introducing the following line of code (to prevent type mismatch):
`j_thetas = j_thetas.astype('float64')`

This pull request also has an additional test in resample/tests folder that covers the case where estimator returns an integer