### PR TITLE
Resample several arguments

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -77,9 +77,8 @@ def resample(
             from numpy import VisibleDeprecationWarning
 
             warnings.warn(
-                "Calling resample with named positional arguments like size etc. is "
-                "deprecated. Please change resample(array, 10, ...) to "
-                "resample(array, size=10, ...)",
+                "Calling resample with positional instead of keyword arguments is "
+                "deprecated",
                 VisibleDeprecationWarning,
             )
             if len(args) == 1:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -363,3 +363,49 @@ def test_random_state():
 
     with pytest.raises(TypeError):
         resample(d, size=5, random_state=1.5)
+
+
+@pytest.mark.parametrize("method", NON_PARAMETRIC)
+def test_resample_several_args(method, rng):
+    a = [1, 2, 3]
+    b = [(1, 2), (2, 3), (3, 4)]
+    ai_different = False
+    bi_different = False
+    for ai, bi in resample(a, b, size=5, method=method, random_state=rng):
+        assert np.shape(ai) == (3,)
+        assert np.shape(bi) == (3, 2)
+        assert set(ai) <= set(a)
+        bi = list(tuple(x) for x in bi)
+        assert set(bi) <= set(b)
+        ai_different |= np.all(ai != a)
+        bi_different |= np.all(bi != b)
+    assert ai_different
+    assert bi_different
+
+    for ai, bi, ci in resample(a, b, ["12", "3", "4"], size=5, random_state=rng):
+        assert np.shape(ai) == (3,)
+        assert np.shape(bi) == (3, 2)
+        assert np.shape(ci) == (3,)
+
+
+def test_resample_several_args_incompatible_keywords():
+    a = [1, 2, 3]
+    b = [(1, 2), (2, 3), (3, 4)]
+    with pytest.raises(ValueError):
+        resample(a, b, size=5, method="norm")
+
+    resample(a, size=5, strata=[1, 1, 2])
+
+    with pytest.raises(ValueError):
+        resample(a, b, size=5, strata=[1, 1, 2])
+
+    resample(a, b, a, b, size=5)
+
+    with pytest.raises(ValueError):
+        resample(a, [1, 2])
+
+    with pytest.raises(ValueError):
+        resample(a, [1, 2, 3, 4])
+
+    with pytest.raises(ValueError):
+        resample(a, b, 5)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -366,26 +366,38 @@ def test_random_state():
 
 
 @pytest.mark.parametrize("method", NON_PARAMETRIC)
-def test_resample_several_args(method, rng):
+def test_resample_several_args(method):
     a = [1, 2, 3]
     b = [(1, 2), (2, 3), (3, 4)]
-    ai_different = False
-    bi_different = False
-    for ai, bi in resample(a, b, size=5, method=method, random_state=rng):
-        assert np.shape(ai) == (3,)
-        assert np.shape(bi) == (3, 2)
-        assert set(ai) <= set(a)
-        bi = list(tuple(x) for x in bi)
-        assert set(bi) <= set(b)
-        ai_different |= np.all(ai != a)
-        bi_different |= np.all(bi != b)
-    assert ai_different
-    assert bi_different
-
-    for ai, bi, ci in resample(a, b, ["12", "3", "4"], size=5, random_state=rng):
+    c = ["12", "3", "4"]
+    r = []
+    for ai, bi, ci in resample(a, b, c, size=5, method=method, random_state=1):
         assert np.shape(ai) == (3,)
         assert np.shape(bi) == (3, 2)
         assert np.shape(ci) == (3,)
+        assert set(ai) <= set(a)
+        assert set(ci) <= set(c)
+        bi = list(tuple(x) for x in bi)
+        assert set(bi) <= set(b)
+
+        for aii, bii, cii in zip(ai, bi, ci):
+            r.append((aii, bii, cii))
+
+    r = np.array(r, dtype=object)
+    abc = []
+    for ai, bi, ci in zip(a, b, c):
+        abc.append((ai, bi, ci))
+    r2 = np.concatenate(
+        list(
+            resample(
+                np.array(abc, dtype=object),
+                size=5,
+                method=method,
+                random_state=1,
+            ),
+        )
+    )
+    assert_equal(r, r2)
 
 
 def test_resample_several_args_incompatible_keywords():

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -320,7 +320,7 @@ def test_variance(method, rng):
     assert r == pytest.approx(v, rel=0.05)
 
 
-def test_deprecation(rng):
+def test_resample_deprecation(rng):
     data = [1, 2, 3]
     from numpy import VisibleDeprecationWarning
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -56,7 +56,7 @@ def test_resample_shape_1d(method):
     n_rep = 5
     count = 0
     with np.errstate(invalid="ignore"):
-        for bx in resample(x, n_rep, method=method):
+        for bx in resample(x, size=n_rep, method=method):
             assert len(bx) == len(x)
             count += 1
     assert count == n_rep
@@ -67,7 +67,7 @@ def test_resample_shape_2d(method):
     x = [(1.0, 2.0), (4.0, 3.0), (6.0, 5.0)]
     n_rep = 5
     count = 0
-    for bx in resample(x, n_rep, method=method):
+    for bx in resample(x, size=n_rep, method=method):
         assert bx.shape == np.shape(x)
         count += 1
     assert count == n_rep
@@ -78,7 +78,7 @@ def test_resample_shape_4d(method):
     x = np.ones((2, 3, 4, 5))
     n_rep = 5
     count = 0
-    for bx in resample(x, 5, method=method):
+    for bx in resample(x, size=n_rep, method=method):
         assert bx.shape == np.shape(x)
         count += 1
     assert count == n_rep
@@ -121,7 +121,7 @@ def test_resample_1d_statistical_test(method, rng):
     prob = []
     wsum = 0
     with np.errstate(invalid="ignore"):
-        for bx in resample(x, 100, method=method, random_state=rng):
+        for bx in resample(x, size=100, method=method, random_state=rng):
             w = np.histogram(bx, bins=xe)[0]
             wsum += w
             pvalue = chisquare(w, wref)
@@ -150,7 +150,7 @@ def test_resample_1d_statistical_test_poisson(rng):
 
     # compute P values for replicates compared to original
     prob = []
-    for bx in resample(x, 100, method="poisson", random_state=rng):
+    for bx in resample(x, size=100, method="poisson", random_state=rng):
         w = np.histogram(bx, bins=xe)[0]
 
         pvalue = chisquare(w, wref)
@@ -318,3 +318,48 @@ def test_variance(method, rng):
 
     r = variance(np.mean, data, size=1000, method=method, random_state=rng)
     assert r == pytest.approx(v, rel=0.05)
+
+
+def test_deprecation(rng):
+    data = [1, 2, 3]
+    from numpy import VisibleDeprecationWarning
+
+    with pytest.warns(VisibleDeprecationWarning):
+        r = list(resample(data, 10))
+        assert np.shape(r) == (10, 3)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        resample(data, 10, "balanced")
+
+    with pytest.warns(VisibleDeprecationWarning):
+        with pytest.raises(ValueError):
+            resample(data, 10, "foo")
+
+    with pytest.warns(VisibleDeprecationWarning):
+        resample(data, 10, "balanced", [1, 1, 2])
+
+    with pytest.warns(VisibleDeprecationWarning):
+        with pytest.raises(ValueError):
+            resample(data, 10, "balanced", [1, 1])
+
+    with pytest.warns(VisibleDeprecationWarning):
+        resample(data, 10, "balanced", [1, 1, 2], rng)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        resample(data, 10, "balanced", [1, 1, 2], 1)
+
+    with pytest.warns(VisibleDeprecationWarning):
+        with pytest.raises(TypeError):
+            resample(data, 10, "balanced", [1, 1, 2], 1.3)
+
+
+def test_random_state():
+    d = [1, 2, 3]
+    a = list(resample(d, size=5, random_state=np.random.default_rng(1)))
+    b = list(resample(d, size=5, random_state=1))
+    c = list(resample(d, size=5, random_state=[2, 3]))
+    assert_equal(a, b)
+    assert not np.all([np.all(ai == ci) for (ai, ci) in zip(a, c)])
+
+    with pytest.raises(TypeError):
+        resample(d, size=5, random_state=1.5)

--- a/tests/test_jackknife.py
+++ b/tests/test_jackknife.py
@@ -83,3 +83,36 @@ def test_variance():
     # ((3/2 - 1)^2 + (1 - 1)^2 + (1/2 - 1)^2) * 2 / 3
     # (1/4 + 1/4) / 3 * 2 = 1/3
     assert r == pytest.approx(1.0 / 3.0)
+
+
+def test_resample_several_args():
+    a = [1, 2, 3]
+    b = [(1, 2), (2, 3), (3, 4)]
+    c = ["12", "3", "4"]
+    for ai, bi, ci in resample(a, b, c):
+        assert np.shape(ai) == (2,)
+        assert np.shape(bi) == (2, 2)
+        assert np.shape(ci) == (2,)
+        assert set(ai) <= set(a)
+        assert set(ci) <= set(c)
+        bi = list(tuple(x) for x in bi)
+        assert set(bi) <= set(b)
+
+
+def test_resample_several_args_incompatible_keywords():
+    a = [1, 2, 3]
+    with pytest.raises(ValueError):
+        resample(a, [1, 2])
+
+    with pytest.raises(ValueError):
+        resample(a, [1, 2, 3, 4])
+
+
+def test_resample_deprecation():
+    data = [1, 2, 3]
+    from numpy import VisibleDeprecationWarning
+
+    with pytest.warns(VisibleDeprecationWarning):
+        r = list(resample(data, True))
+
+    assert_equal(r, list(resample(data, copy=True)))


### PR DESCRIPTION
Closes #112 

This allows 

```py
for ai, bi, ... in resample(a, b, ...):
   pass
```
under the condition that `a`, `b`, ... have the same lengths. The arguments are resampled in such a way that the relative pairings remain intact, e.g. the pair `a[1], b[1]` may be duplicated by the resampling at `a[5], b[5]`.

Code with positional arguments like `resample(a, 10)` for `resample(a, size=10)` is still working, but generates a `VisibleDeprecationWarning`.