### PR TITLE
Support several args in additional bootstrap functions

### DIFF
--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -70,7 +70,7 @@ def resample(
     """
     sample_np = np.atleast_1d(sample)
     n_sample = len(sample_np)
-    args_np = []
+    args_np: _tp.List[np.ndarray] = []
     if args:
         if not isinstance(args[0], _tp.Iterable):
             import warnings
@@ -92,7 +92,9 @@ def resample(
                 size, method, strata, random_state = args
             else:
                 raise ValueError("too many arguments")
+            del args
         else:
+            args_np = []
             args_np.append(sample_np)
             for arg in args:
                 arg = np.atleast_1d(arg)
@@ -249,6 +251,8 @@ def confidence_interval(
                 cl, ci_method = args
             else:
                 raise ValueError("too many arguments")
+
+            args = ()
 
     if not 0 < cl < 1:
         raise ValueError("cl must be between zero and one")

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -299,7 +299,7 @@ def bias(
     """
     thetas = []
     if args:
-        replicates: _tp.List[_tp.Any] = [[] for _ in range(len(args) + 1)]
+        replicates: _tp.List[_tp.List] = [[] for _ in range(len(args) + 1)]
         for b in resample(sample, *args, **kwargs):
             for ri, bi in zip(replicates, b):
                 ri.append(bi)

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -20,7 +20,7 @@ from resample.empirical import quantile_function_gen
 from resample.jackknife import jackknife
 
 _Kwargs = _tp.Any
-_Args = _tp.Tuple[_tp.Any]
+_Args = _tp.Any
 
 
 def resample(

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -251,7 +251,6 @@ def confidence_interval(
                 cl, ci_method = args
             else:
                 raise ValueError("too many arguments")
-
             args = ()
 
     if not 0 < cl < 1:

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -20,11 +20,12 @@ from resample.empirical import quantile_function_gen
 from resample.jackknife import jackknife
 
 _Kwargs = _tp.Any
+_Args = _tp.Tuple[_tp.Any]
 
 
 def resample(
     sample: _tp.Iterable,
-    *args: _tp.Tuple[_tp.Any],
+    *args: _Args,
     size: int = 100,
     method: str = "balanced",
     strata: _tp.Optional[_tp.Iterable] = None,
@@ -158,7 +159,9 @@ def resample(
     return _resample_parametric(sample_np, size, dist, rng)
 
 
-def bootstrap(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.ndarray:
+def bootstrap(
+    fn: _tp.Callable, sample: _tp.Iterable, *args: _Args, **kwargs: _Kwargs
+) -> np.ndarray:
     """
     Calculate function values from bootstrap samples.
 
@@ -168,6 +171,8 @@ def bootstrap(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.n
         Bootstrap samples are passed to this function.
     sample : array-like
         Original sample.
+    *args : array-like
+        Optional additional arrays of the same length to resample.
     **kwargs
         Keywords are forwarded to :func:`resample`.
 
@@ -176,13 +181,16 @@ def bootstrap(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.n
     np.array
         Results of `fn` applied to each bootstrap sample.
     """
-    return np.asarray([fn(x) for x in resample(sample, **kwargs)])
+    gen = resample(sample, *args, **kwargs)
+    if args:
+        return np.array([fn(*b) for b in gen])
+    return np.array([fn(x) for x in gen])
 
 
 def confidence_interval(
     fn: _tp.Callable,
     sample: _tp.Iterable,
-    *,
+    *args: _Args,
     cl: float = 0.95,
     ci_method: str = "bca",
     **kwargs: _Kwargs,
@@ -196,6 +204,8 @@ def confidence_interval(
         Function to be bootstrapped.
     sample : array-like
         Original sample.
+    *args : array-like
+        Optional additional arrays of the same length to resample.
     cl : float, default : 0.95
         Confidence level. Asymptotically, this is the probability that the interval
         contains the true value.
@@ -221,18 +231,37 @@ def confidence_interval(
     'percentile'. However the increase in accuracy should compensate for this, with the
     result that less bootstrap replicas are needed overall to achieve the same accuracy.
     """
+    if args:
+        if not isinstance(args[0], _tp.Iterable):
+            import warnings
+
+            from numpy import VisibleDeprecationWarning
+
+            warnings.warn(
+                "Calling confidence_interval with positional instead of keyword "
+                "arguments is deprecated",
+                VisibleDeprecationWarning,
+            )
+
+            if len(args) == 1:
+                (cl,) = args
+            elif len(args) == 2:
+                cl, ci_method = args
+            else:
+                raise ValueError("too many arguments")
+
     if not 0 < cl < 1:
         raise ValueError("cl must be between zero and one")
 
     alpha = 1 - cl
-    thetas = bootstrap(fn, sample, **kwargs)
+    thetas = bootstrap(fn, sample, *args, **kwargs)
 
     if ci_method == "percentile":
         return _confidence_interval_percentile(thetas, alpha / 2)
 
     if ci_method == "bca":
-        theta = fn(sample)
-        j_thetas = jackknife(fn, sample)
+        theta = fn(sample, *args)
+        j_thetas = jackknife(fn, sample, *args)
         return _confidence_interval_bca(theta, thetas, j_thetas, alpha / 2)
 
     raise ValueError(
@@ -240,7 +269,9 @@ def confidence_interval(
     )
 
 
-def bias(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.ndarray:
+def bias(
+    fn: _tp.Callable, sample: _tp.Iterable, *args: _Args, **kwargs: _Kwargs
+) -> np.ndarray:
     """
     Calculate bias of the function estimate with the bootstrap.
 
@@ -250,6 +281,8 @@ def bias(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.ndarra
         Function to be bootstrapped.
     sample : array-like
         Original sample.
+    *args : array-like
+        Optional additional arrays of the same length to resample.
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
@@ -264,17 +297,25 @@ def bias(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.ndarra
     the original sample in memory at once. The balanced bootstrap is recommended over
     the ordinary bootstrap for bias estimation, it tends to converge faster.
     """
-    replicates = []
     thetas = []
-    for b in resample(sample, **kwargs):
-        replicates.append(b)
-        thetas.append(fn(b))
-    population_theta = fn(np.concatenate(replicates))
+    if args:
+        replicates: _tp.List[_tp.Any] = [[] for _ in range(len(args) + 1)]
+        for b in resample(sample, *args, **kwargs):
+            for ri, bi in zip(replicates, b):
+                ri.append(bi)
+            thetas.append(fn(*b))
+        population_theta = fn(*(np.concatenate(r) for r in replicates))
+    else:
+        replicates = []
+        for b in resample(sample, *args, **kwargs):
+            replicates.append(b)
+            thetas.append(fn(b))
+        population_theta = fn(np.concatenate(replicates))
     return np.mean(thetas, axis=0) - population_theta
 
 
 def bias_corrected(
-    fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs
+    fn: _tp.Callable, sample: _tp.Iterable, *args: _Args, **kwargs: _Kwargs
 ) -> np.ndarray:
     """
     Calculate bias-corrected estimate of the function with the bootstrap.
@@ -286,6 +327,8 @@ def bias_corrected(
         and k is the length of the output array.
     sample : array-like
         Original sample.
+    *args : array-like
+        Optional additional arrays of the same length to resample.
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
@@ -294,10 +337,12 @@ def bias_corrected(
     ndarray
         Estimate with some bias removed.
     """
-    return fn(sample) - bias(fn, sample, **kwargs)
+    return fn(sample, *args) - bias(fn, sample, *args, **kwargs)
 
 
-def variance(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.ndarray:
+def variance(
+    fn: _tp.Callable, sample: _tp.Iterable, *args: _Args, **kwargs: _Kwargs
+) -> np.ndarray:
     """
     Calculate bootstrap estimate of variance.
 
@@ -308,6 +353,8 @@ def variance(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.nd
         and k is the length of the output array.
     sample : array-like
         Original sample.
+    *args : array-like
+        Optional additional arrays of the same length to resample.
     **kwargs
         Keyword arguments forwarded to :func:`resample`.
 
@@ -316,7 +363,7 @@ def variance(fn: _tp.Callable, sample: _tp.Iterable, **kwargs: _Kwargs) -> np.nd
     ndarray
         Bootstrap estimate of variance.
     """
-    thetas = bootstrap(fn, sample, **kwargs)
+    thetas = bootstrap(fn, sample, *args, **kwargs)
     return np.var(thetas, ddof=1, axis=0)
 
 
@@ -351,7 +398,7 @@ def _resample_ordinary_n(
     indices = np.arange(n)
     for _ in range(size):
         m = rng.choice(indices, size=n, replace=True)
-        yield (s[m] for s in samples)
+        yield tuple(s[m] for s in samples)
 
 
 def _resample_balanced_1(
@@ -373,7 +420,7 @@ def _resample_balanced_n(
     indices = rng.permutation(n * size)
     for i in range(size):
         m = indices[i * n : (i + 1) * n] % n
-        yield (s[m] for s in samples)
+        yield tuple(s[m] for s in samples)
 
 
 def _fit_parametric_family(

--- a/resample/bootstrap.py
+++ b/resample/bootstrap.py
@@ -256,8 +256,8 @@ def confidence_interval(
     if not 0 < cl < 1:
         raise ValueError("cl must be between zero and one")
 
-    alpha = 1 - cl
     thetas = bootstrap(fn, sample, *args, **kwargs)
+    alpha = 1 - cl
 
     if ci_method == "percentile":
         return _confidence_interval_percentile(thetas, alpha / 2)

--- a/resample/jackknife.py
+++ b/resample/jackknife.py
@@ -16,7 +16,7 @@ import typing as _tp
 
 import numpy as np
 
-_Args = _tp.Tuple[_tp.Any]
+_Args = _tp.Any
 
 
 def resample(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -388,16 +388,16 @@ def test_confidence_interval_deprecation(rng):
 
     d = [1, 2, 3]
     with pytest.warns(VisibleDeprecationWarning):
-        r = confidence_interval(np.mean, d, 0.5)
-    assert_equal(r, confidence_interval(np.mean, d, cl=0.5))
+        r = confidence_interval(np.mean, d, 0.6)
+    assert_equal(r, confidence_interval(np.mean, d, cl=0.6))
 
     with pytest.warns(VisibleDeprecationWarning):
-        r = confidence_interval(np.mean, d, 0.5, "percentile")
-    assert_equal(r, confidence_interval(np.mean, d, cl=0.5, ci_method="percentile"))
+        r = confidence_interval(np.mean, d, 0.6, "percentile")
+    assert_equal(r, confidence_interval(np.mean, d, cl=0.6, ci_method="percentile"))
 
     with pytest.warns(VisibleDeprecationWarning):
         with pytest.raises(ValueError):
-            confidence_interval(np.mean, d, 0.5, "percentile", 1)
+            confidence_interval(np.mean, d, 0.6, "percentile", 1)
 
 
 def test_random_state():

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -388,12 +388,15 @@ def test_confidence_interval_deprecation(rng):
 
     d = [1, 2, 3]
     with pytest.warns(VisibleDeprecationWarning):
-        r = confidence_interval(np.mean, d, 0.6)
-    assert_equal(r, confidence_interval(np.mean, d, cl=0.6))
+        r = confidence_interval(np.mean, d, 0.6, random_state=1)
+    assert_equal(r, confidence_interval(np.mean, d, cl=0.6, random_state=1))
 
     with pytest.warns(VisibleDeprecationWarning):
-        r = confidence_interval(np.mean, d, 0.6, "percentile")
-    assert_equal(r, confidence_interval(np.mean, d, cl=0.6, ci_method="percentile"))
+        r = confidence_interval(np.mean, d, 0.6, "percentile", random_state=1)
+    assert_equal(
+        r,
+        confidence_interval(np.mean, d, cl=0.6, ci_method="percentile", random_state=1),
+    )
 
     with pytest.warns(VisibleDeprecationWarning):
         with pytest.raises(ValueError):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -383,6 +383,23 @@ def test_resample_deprecation(rng):
             resample(data, 10, "balanced", [1, 1, 2], 1.3)
 
 
+def test_confidence_interval_deprecation(rng):
+    from numpy import VisibleDeprecationWarning
+
+    d = [1, 2, 3]
+    with pytest.warns(VisibleDeprecationWarning):
+        r = confidence_interval(np.mean, d, 0.5)
+    assert_equal(r, confidence_interval(np.mean, d, cl=0.5))
+
+    with pytest.warns(VisibleDeprecationWarning):
+        r = confidence_interval(np.mean, d, 0.5, "percentile")
+    assert_equal(r, confidence_interval(np.mean, d, cl=0.5, ci_method="percentile"))
+
+    with pytest.warns(VisibleDeprecationWarning):
+        with pytest.raises(ValueError):
+            confidence_interval(np.mean, d, 0.5, "percentile", 1)
+
+
 def test_random_state():
     d = [1, 2, 3]
     a = list(resample(d, size=5, random_state=np.random.default_rng(1)))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -213,6 +213,36 @@ def test_bootstrap_2d_balanced(rng):
     assert_almost_equal(mean(data), mean(r))
 
 
+@pytest.mark.parametrize(
+    "action", [bootstrap, bias, bias_corrected, variance, confidence_interval]
+)
+def test_bootstrap_several_args(action):
+    x = [1, 2, 3]
+    y = [4, 5, 6]
+    xy = np.transpose([x, y])
+
+    if action is confidence_interval:
+
+        def f1(x, y):
+            return np.sum(x + y)
+
+        def f2(xy):
+            return np.sum(xy)
+
+    else:
+
+        def f1(x, y):
+            return np.sum(x), np.sum(y)
+
+        def f2(xy):
+            return np.sum(xy, axis=0)
+
+    r1 = action(f1, x, y, size=10, random_state=1)
+    r2 = action(f2, xy, size=10, random_state=1)
+
+    assert_equal(r1, r2)
+
+
 @pytest.mark.parametrize("ci_method", ["percentile", "bca"])
 def test_confidence_interval(ci_method, rng):
     data = rng.normal(size=1000)
@@ -370,34 +400,24 @@ def test_resample_several_args(method):
     a = [1, 2, 3]
     b = [(1, 2), (2, 3), (3, 4)]
     c = ["12", "3", "4"]
-    r = []
+    r1 = [[], [], []]
     for ai, bi, ci in resample(a, b, c, size=5, method=method, random_state=1):
-        assert np.shape(ai) == (3,)
-        assert np.shape(bi) == (3, 2)
-        assert np.shape(ci) == (3,)
-        assert set(ai) <= set(a)
-        assert set(ci) <= set(c)
-        bi = list(tuple(x) for x in bi)
-        assert set(bi) <= set(b)
+        r1[0].append(ai)
+        r1[1].append(bi)
+        r1[2].append(ci)
 
-        for aii, bii, cii in zip(ai, bi, ci):
-            r.append((aii, bii, cii))
+    r2 = [[], [], []]
+    abc = np.empty(3, dtype=[("a", "i"), ("b", "i", 2), ("c", "U4")])
+    abc[:]["a"] = a
+    abc[:]["b"] = b
+    abc[:]["c"] = c
+    for abci in resample(abc, size=5, method=method, random_state=1):
+        r2[0].append(abci["a"])
+        r2[1].append(abci["b"])
+        r2[2].append(abci["c"])
 
-    r = np.array(r, dtype=object)
-    abc = []
-    for ai, bi, ci in zip(a, b, c):
-        abc.append((ai, bi, ci))
-    r2 = np.concatenate(
-        list(
-            resample(
-                np.array(abc, dtype=object),
-                size=5,
-                method=method,
-                random_state=1,
-            ),
-        )
-    )
-    assert_equal(r, r2)
+    for i in range(3):
+        assert_equal(r1[i], r2[i])
 
 
 def test_resample_several_args_incompatible_keywords():


### PR DESCRIPTION
We want to support extra args in most other functions as well, not only in `resample`. This is implemented here.