### PR TITLE
Fix dynamic calculation of required test samples

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,4 +28,6 @@ jobs:
     - run: python -m pip install --upgrade pip wheel
     - run: python -m pip install -e .[test]
     - run: coverage run -m pytest
+    - run: python -m pip uninstall numba
+    - run: coverage run -m pytest
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,6 @@ jobs:
     - run: python -m pip install --upgrade pip wheel
     - run: python -m pip install -e .[test]
     - run: coverage run -m pytest
-    - run: python -m pip uninstall numba
+    - run: python -m pip uninstall --yes numba
     - run: coverage run -m pytest
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,5 +29,5 @@ jobs:
     - run: python -m pip install -e .[test]
     - run: coverage run -m pytest
     - run: python -m pip uninstall --yes numba
-    - run: coverage run -m pytest
+    - run: coverage run --append -m pytest
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *checkpoints*
 build
 dist
+prof
 resample.egg-info
 install_log.txt
 *__pycache__

--- a/benchmarks/test_usp.py
+++ b/benchmarks/test_usp.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+from resample.permutation import usp
+
+
+@pytest.mark.parametrize("m", (2, 10, 100, 1000))
+@pytest.mark.parametrize("n", (2, 10, 100, 1000))
+def test_usp(m, n, benchmark):
+    rng = np.random.default_rng(1)
+    x = rng.normal(0, 1, size=10000)
+    y = rng.normal(0, 1, size=10000)
+    w = np.histogram2d(x, y, bins=(m, n))[0]
+    benchmark(lambda: usp(w, precision=0, max_size=100))

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ test =
     pytest
     pytest-cov
     pytest-benchmark
+    numba
 
 [tool:pytest]
 testpaths = tests

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -210,13 +210,15 @@ def test_usp_3(rng):
 def test_usp_4():
     # table1 from https://doi.org/10.1098/rspa.2021.0549
     w = [[18, 36, 21, 9, 6], [12, 36, 45, 36, 21], [6, 9, 9, 3, 3], [3, 9, 9, 6, 3]]
-    r = perm.usp(w, precision=0, max_size=1000, random_state=1)
+    r1 = perm.usp(w, precision=0, max_size=1000, random_state=1)
+    r2 = perm.usp(np.transpose(w), precision=0, max_size=1000, random_state=1)
+    assert_allclose(r1.statistic, r2.statistic)
     expected = 0.005216488  # according to Richard Samworth, send by email
-    assert_allclose(r.statistic, expected)
+    assert_allclose(r1.statistic, expected)
     # according to paper, pvalue is 0.001, but we get 0.0025 in high-statistics runs
-    assert_allclose(r.pvalue, 0.0025, atol=0.001)
+    assert_allclose(r1.pvalue, 0.0025, atol=0.001)
     _, interval = perm._wilson_score_interval(0.0025 * 1000, 1000, 1)
-    assert_allclose(r.interval, interval, atol=0.001)
+    assert_allclose(r1.interval, interval, atol=0.001)
 
 
 def test_usp_bad_input():

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -268,4 +268,4 @@ def test_precision(test, prec, rng):
         assert len(r.samples) == 123
     else:
         actual_precision = (r.interval[1] - r.interval[0]) / 2
-        assert_allclose(actual_precision, prec, atol=0.25 * prec)
+        assert_allclose(actual_precision, prec, atol=0.5 * prec)

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -211,6 +211,8 @@ def test_usp_4():
     # table1 from https://doi.org/10.1098/rspa.2021.0549
     w = [[18, 36, 21, 9, 6], [12, 36, 45, 36, 21], [6, 9, 9, 3, 3], [3, 9, 9, 6, 3]]
     r = perm.usp(w, precision=0, max_size=1000, random_state=1)
+    expected = 0.005216488  # according to Richard Samworth, send by email
+    assert_allclose(r.statistic, expected)
     # according to paper, pvalue is 0.001, but we get 0.0025 in high-statistics runs
     assert_allclose(r.pvalue, 0.0025, atol=0.001)
     _, interval = perm._wilson_score_interval(0.0025 * 1000, 1000, 1)

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -193,8 +193,8 @@ def test_usp_2(rng):
 
 def test_usp_3(rng):
     cov = np.empty((2, 2))
-    cov[0, 0] = 2 ** 2
-    cov[1, 1] = 3 ** 2
+    cov[0, 0] = 2**2
+    cov[1, 1] = 3**2
     rho = 0.5
     cov[0, 1] = rho * np.sqrt(cov[0, 0] * cov[1, 1])
     cov[1, 0] = cov[0, 1]
@@ -213,8 +213,8 @@ def test_usp_4():
     r1 = perm.usp(w, precision=0, max_size=1000, random_state=1)
     r2 = perm.usp(np.transpose(w), precision=0, max_size=1000, random_state=1)
     assert_allclose(r1.statistic, r2.statistic)
-    expected = 0.005216488  # according to Richard Samworth, send by email
-    assert_allclose(r1.statistic, expected)
+    expected = 0.004106  # checked against R implementation
+    assert_allclose(r1.statistic, expected, atol=1e-6)
     # according to paper, pvalue is 0.001, but we get 0.0025 in high-statistics runs
     assert_allclose(r1.pvalue, 0.0025, atol=0.001)
     _, interval = perm._wilson_score_interval(0.0025 * 1000, 1000, 1)
@@ -254,7 +254,7 @@ def test_ttest_bad_input():
 
 @pytest.mark.parametrize("test", (perm.ttest, perm.usp))
 @pytest.mark.parametrize("prec", (0, 0.05, 0.005))
-def test_precision_1(test, prec, rng):
+def test_precision(test, prec, rng):
     x = rng.normal(0, 1, size=100)
     y = rng.normal(0, 2, size=100)
     if test is perm.ttest:
@@ -263,9 +263,9 @@ def test_precision_1(test, prec, rng):
         w = np.histogram2d(x, y)[0]
         args = (w,)
 
-    r = test(*args, precision=prec, max_size=10000 if prec > 0 else 123)
+    r = test(*args, precision=prec, max_size=10000 if prec > 0 else 123, random_state=1)
     if prec == 0:
         assert len(r.samples) == 123
     else:
-        assert (r.interval[1] - r.interval[0]) / 2 < prec
-        assert_allclose((r.interval[1] - r.interval[0]) / 2, prec, atol=0.5 * prec)
+        actual_precision = (r.interval[1] - r.interval[0]) / 2
+        assert_allclose(actual_precision, prec, atol=0.25 * prec)


### PR DESCRIPTION
Richard Samworth pointed out in a comment by email, that an iterative algorithm which computes the number permutation samples dynamically makes the number of permutations used by the test a function of the resampled data set, but it has to be independent of that set if the Type I error probabilities should hold theoretically.

One possibility was to use the worst case value 0.5 and compute the number of required samples from that, but this is very pessimistic when the pvalue is very small (orders of magnitude). As a compromise, this patch uses only two iterations. In the first iteration, a burn sample of 10 permutations is used to get a crude estimate of the pvalue. The required number of samples is then computed from the pvalue obtained in the burn sample. The second sample is statistically independent of the first, so this should avoid the problem.