### PR TITLE
attempt to fix build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,6 @@ jobs:
     - run: python -m pip install --upgrade pip
     - run: python -m pip install -e .[test]
     - run: coverage run -m pytest
-    - run: python -m pip uninstall --yes numba cython
+    - run: python -m pip uninstall --yes numba
     - run: coverage run --append -m pytest
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,11 +29,8 @@ jobs:
       with:
         python-version: "3.8"
     - run: python -m pip install --upgrade pip
-    # workaround to avoid having different numpy versions during build/test
-    - run: python -m pip install wheel numpy setuptools setuptools_scm[toml]
-    - run: python -m pip install pytest pytest-cov numba
-    - run: python -m pip install --no-build-isolation -e .
+    - run: python -m pip install -e .[test]
     - run: coverage run -m pytest
-    - run: python -m pip uninstall --yes numba
+    - run: python -m pip uninstall --yes numba cython
     - run: coverage run --append -m pytest
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,5 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install --upgrade pip
-    # workaround to avoid having different numpy versions during build/test
-    - run: |
-        python -m pip install wheel numpy setuptools setuptools_scm[toml]
-        python -m pip install pytest numba
-        python -m pip install --no-build-isolation -e .
+    - run: python -m pip install -e .[test]
     - run: python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ requires = [
     "setuptools_scm[toml] >= 3.4",
     # numpy 1.19 is first to support C-API for random
     # use oldest numpy for given Python version to ensure compatible Numpy C-API
-    "numpy ~= 1.19; python_version == '3.7'",
-    "numpy ~= 1.19; python_version == '3.8'",
-    "numpy ~= 1.20; python_version == '3.9'",
-    "numpy ~= 1.21; python_version == '3.10'",
+    "numpy == 1.19; python_version == '3.7'",
+    "numpy == 1.19; python_version == '3.8'",
+    "numpy == 1.20; python_version == '3.9'",
+    "numpy == 1.21.2; python_version == '3.10'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = [
     "setuptools >= 42",
     "setuptools_scm[toml] >= 3.4",
     # numpy 1.19 is first to support C-API for random
-    # use oldest numpy for given Python version to ensure compatible Numpy C-API 
+    # use oldest numpy for given Python version to ensure compatible Numpy C-API
     "numpy == 1.19; python_version == '3.7'",
     "numpy == 1.19; python_version == '3.8'",
     "numpy == 1.20; python_version == '3.9'",
-    "numpy == 1.22; python_version == '3.10'",
+    "numpy == 1.21; python_version == '3.10'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ requires = [
     "setuptools_scm[toml] >= 3.4",
     # numpy 1.19 is first to support C-API for random
     # use oldest numpy for given Python version to ensure compatible Numpy C-API
-    "numpy == 1.19; python_version == '3.7'",
-    "numpy == 1.19; python_version == '3.8'",
-    "numpy == 1.20; python_version == '3.9'",
-    "numpy == 1.21; python_version == '3.10'",
+    "numpy ~= 1.19; python_version == '3.7'",
+    "numpy ~= 1.19; python_version == '3.8'",
+    "numpy ~= 1.20; python_version == '3.9'",
+    "numpy ~= 1.21; python_version == '3.10'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,12 @@
 requires = [
     "setuptools >= 42",
     "setuptools_scm[toml] >= 3.4",
-    "numpy == 1.15; python_version ~= 3.7",
-    "numpy == 1.18; python_version ~= 3.8",
-    "numpy == 1.20; python_version ~= 3.9",
-    "numpy == 1.22; python_version ~= 3.10",
+    # numpy 1.19 is first to support C-API for random
+    # use oldest numpy for given Python version to ensure compatible Numpy C-API 
+    "numpy == 1.19; python_version == '3.7'",
+    "numpy == 1.19; python_version == '3.8'",
+    "numpy == 1.20; python_version == '3.9'",
+    "numpy == 1.22; python_version == '3.10'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 42",
     "setuptools_scm[toml] >= 3.4",
-    "numpy",
+    "numpy <= 1.15",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 requires = [
     "setuptools >= 42",
     "setuptools_scm[toml] >= 3.4",
-    "numpy <= 1.15",
+    "numpy == 1.15; python_version ~= 3.7",
+    "numpy == 1.18; python_version ~= 3.8",
+    "numpy == 1.20; python_version ~= 3.9",
+    "numpy == 1.22; python_version ~= 3.10",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,8 @@ package_dir =
 packages = resample
 python_requires = >=3.7
 install_requires =
-    numpy>=1.17
-    scipy>=1.5
+    numpy >= 1.19
+    scipy >= 1.5
 
 [options.extras_require]
 test =

--- a/src/rcont.c
+++ b/src/rcont.c
@@ -55,6 +55,10 @@ int rcont1(double* matrix, int nr, const double* r, int nc, const double* c,
 
     int n = (int)nd;
     *work = (int*)malloc(sizeof(int) * (n + 1));
+    if (!*work) {
+      status = 1;
+      return status;
+    }
     *work[0] = n;
     int* ymap = *work + 1;
     for (int i = 0; i < nc; ++i) {

--- a/src/resample/_ext.c
+++ b/src/resample/_ext.c
@@ -9,9 +9,8 @@ int rcont2(double*, int, const double*, int, const double*, double*, bitgen_t*);
 
 static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
   int n = -1, method = -1;
-  PyObject *r = NULL, *c = NULL, *rng = NULL,
-    *ra = NULL, *ca = NULL, *ma = NULL,
-    *bitgen = NULL, *cap = NULL;
+  PyObject *r = NULL, *c = NULL, *rng = NULL, *bitgen = NULL, *cap = NULL;
+  PyArrayObject *ra = NULL, *ca = NULL, *ma = NULL;
   int* work = 0; // pointer to workspace for rcont_naive, allocated by rcont_naive
 
   if(!PyArg_ParseTuple(args, "iO!O!iO",
@@ -22,9 +21,9 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
     &rng))
     return NULL;
 
-  ra = PyArray_FROM_OTF(r, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+  ra = (PyArrayObject*)PyArray_FROM_OTF(r, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
   if (!ra) goto fail;
-  ca = PyArray_FROM_OTF(c, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+  ca = (PyArrayObject*)PyArray_FROM_OTF(c, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
   if (!ca) goto fail;
 
   if (PyArray_NDIM(ra) != 1) {
@@ -41,7 +40,7 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
   npy_intp* c_shape = PyArray_DIMS(ca);
 
   npy_intp m_shape[3] = {n, *r_shape, *c_shape};
-  ma = PyArray_SimpleNew(3, m_shape, NPY_DOUBLE);
+  ma = (PyArrayObject*)PyArray_SimpleNew(3, m_shape, NPY_DOUBLE);
 
   bitgen = PyObject_GetAttrString(rng, "_bit_generator");
   if (!bitgen) goto fail;
@@ -100,7 +99,7 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
   if (work)
     free(work);
 
-  return ma;
+  return (PyObject*)ma;
 
 fail:
   Py_XDECREF(ra);

--- a/src/resample/_ext.c
+++ b/src/resample/_ext.c
@@ -36,10 +36,10 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
     goto fail;
   }
 
-  npy_intp* r_shape = PyArray_DIMS(ra);
-  npy_intp* c_shape = PyArray_DIMS(ca);
+  npy_intp nr = *PyArray_DIMS(ra);
+  npy_intp nc = *PyArray_DIMS(ca);
 
-  npy_intp m_shape[3] = {n, *r_shape, *c_shape};
+  npy_intp m_shape[3] = {n, nr, nc};
   ma = (PyArrayObject*)PyArray_SimpleNew(3, m_shape, NPY_DOUBLE);
 
   bitgen = PyObject_GetAttrString(rng, "_bit_generator");
@@ -60,10 +60,10 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
     double* m_ptr = (double*)PyArray_GETPTR3(ma, i, 0, 0);
     switch (method) {
     case 0:
-      status = rcont1(m_ptr, r_shape[0], r_ptr, c_shape[0], c_ptr, &work, rstate);
+      status = rcont1(m_ptr, nr, r_ptr, nc, c_ptr, &work, rstate);
       break;
     case 1:
-      status = rcont2(m_ptr, r_shape[0], r_ptr, c_shape[0], c_ptr, &ntot, rstate);
+      status = rcont2(m_ptr, nr, r_ptr, nc, c_ptr, &ntot, rstate);
       break;
     default:
       PyErr_SetString(PyExc_ValueError, "method must be 0 or 1");
@@ -71,8 +71,7 @@ static PyObject* rcont_wrap(PyObject *self, PyObject *args) {
     }
     switch(status) {
       case 1:
-        // this should never happen and is only listed for completeness
-        PyErr_SetString(PyExc_RuntimeError, "null pointer encountered");
+        PyErr_SetString(PyExc_RuntimeError, "null pointer encountered in memory access");
         goto fail;
       case 2:
         PyErr_SetString(PyExc_ValueError, "number of rows or columns < 2");


### PR DESCRIPTION
We pin the numpy version during build to the oldest version supported by that version of python, to avoid using a newer Numpy C-API during the build than what is available at runtime.
